### PR TITLE
Implement chat update route

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -242,6 +242,7 @@
   let userContext = '';
   const conversation = [];
   const chatHistory = [];
+  let chatId = null;
 
 
   let hasStarted = false;
@@ -340,16 +341,26 @@
 
   async function saveChat() {
     try {
-      await fetch('http://localhost:3000/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: userName,
-          email: userEmail,
-          info: userContext,
-          conversation: chatHistory
-        })
-      });
+      if (!chatId) {
+        const res = await fetch('http://localhost:3000/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: userName,
+            email: userEmail,
+            info: userContext,
+            conversation: chatHistory
+          })
+        });
+        const data = await res.json();
+        chatId = data.id;
+      } else {
+        await fetch(`http://localhost:3000/api/chat/${chatId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ conversation: chatHistory })
+        });
+      }
 
       console.log('saved');
       

--- a/routers/chat.route.js
+++ b/routers/chat.route.js
@@ -33,4 +33,27 @@ router.post('/', async (req, res) => {
   }
 });
 
+router.put('/:id', async (req, res) => {
+  const { id } = req.params;
+  const { conversation } = req.body;
+
+  if (!id || !Array.isArray(conversation)) {
+    return res.status(400).json({ success: false, message: 'id and conversation are required' });
+  }
+
+  try {
+    await client.data
+      .merger()
+      .withClassName('Chat')
+      .withId(id)
+      .withProperties({ conversation: JSON.stringify(conversation) })
+      .do();
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error updating chat in Weaviate:', err.message);
+    res.status(500).json({ success: false, message: 'Failed to update chat' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- allow updating existing chat sessions
- track chat id in frontend
- update conversation via new API route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876c8f50c4083249d5d90cb0951899c