### PR TITLE
Enable chat history memory

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -322,7 +322,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           question,
-          conversation
+          conversation: chatHistory
         }),
       });
       const data = await response.json();


### PR DESCRIPTION
## Summary
- use BufferMemory to preserve chat history for QA
- send chatHistory from the frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876cad5c2108324a7126a93f206de5e