### PR TITLE
Add website context support

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -391,6 +391,7 @@
   const conversation = [];
   const chatHistory = [];
   let chatId = null;
+  let scrapedContent = '';
 
   async function scrapeWebsite() {
     const url = urlInput.value.trim();
@@ -411,8 +412,10 @@
       const data = await response.json();
       messagesDiv.removeChild(typingDiv);
       if (response.ok) {
+        scrapedContent = data.text || '';
         messagesDiv.innerHTML += `<div class="message bot">${data.message}</div>`;
       } else {
+        scrapedContent = '';
         messagesDiv.innerHTML += `<div class="message bot">❌ ${data.message}</div>`;
       }
       messagesDiv.scrollTop = messagesDiv.scrollHeight;
@@ -552,7 +555,8 @@
         body: JSON.stringify({
           question,
           conversation: chatHistory,
-          model: selectedModel
+          model: selectedModel,
+          webContent: scrapedContent
         }),
       });
       const data = await response.json();

--- a/routers/question.route.js
+++ b/routers/question.route.js
@@ -1,60 +1,10 @@
 import express from "express";
-import { ChatOpenAI } from "@langchain/openai";
-import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
-import { ConversationChain } from "langchain/chains";
-import { BufferMemory, ChatMessageHistory } from "langchain/memory";
+import { qa } from "../utils/qa.js";
 
 const router = express.Router();
 
-const qa = async (question, history = [], modelChoice = "gpt-4o") => {
-    if (!question || typeof question !== "string") {
-        throw new Error("Invalid question provided.");
-    }
-
-    const chatHistory = new ChatMessageHistory();
-    for (const msg of history) {
-        if (msg.role === 'user') {
-            await chatHistory.addUserMessage(msg.text);
-        } else if (msg.role === 'bot') {
-            await chatHistory.addAIChatMessage(msg.text);
-        }
-    }
-
-    const memory = new BufferMemory({ chatHistory, returnMessages: true });
-    let model;
-    if (modelChoice === 'gemini') {
-         if (!process.env.GOOGLE_API_KEY) {s
-        throw new Error("Missing GOOGLE_API_KEY");
-    }
-        model = new ChatGoogleGenerativeAI({
-            model: 'gemini-2.5-flash',
-            apiKey: process.env.GOOGLE_API_KEY,
-            temperature: 0,
-        });
-
-    
-        
-    } else {
-        model = new ChatOpenAI({
-            temperature: 0,
-            modelName: 'gpt-4o-mini',
-            apiKey: process.env.OPEN_AI_KEY
-        });
-    }
-
-    const chain = new ConversationChain({ llm: model, memory });
-
-    try {
-        const res = await chain.call({ input: question });
-        return res.response;
-    } catch (error) {
-        console.error("Error during QA processing:", error);
-        throw new Error("Failed to process the question. Please try again.");
-    }
-};
-
 router.post("/", async (req, res) => {
-    const { question, conversation, model } = req.body;
+    const { question, conversation, model, webContent } = req.body;
 
     try {
         if (!question) {
@@ -64,7 +14,8 @@ router.post("/", async (req, res) => {
         const answer = await qa(
             question,
             Array.isArray(conversation) ? conversation : [],
-            typeof model === 'string' ? model : 'gpt-4o'
+            typeof model === 'string' ? model : 'gpt-4o',
+            typeof webContent === 'string' ? webContent : ''
         );
         res.status(201).json({
             success: true,

--- a/routers/rag.route.js
+++ b/routers/rag.route.js
@@ -81,7 +81,7 @@ router.post('/', async (req, res) => {
       })
     );
 
-    return res.json({ message: 'Successful', content: vectorContent });
+    return res.json({ message: 'Successful', content: vectorContent, text: cleanContent });
   } catch (error) {
     console.error('Error in POST /api/rag:', error);
     return res.status(500).json({ message: 'Failed to scrape the website', error: error.message });

--- a/utils/qa.js
+++ b/utils/qa.js
@@ -1,0 +1,55 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { ConversationChain } from "langchain/chains";
+import { BufferMemory, ChatMessageHistory } from "langchain/memory";
+
+export const qa = async (question, history = [], modelChoice = "gpt-4o", webContent = "") => {
+  if (!question || typeof question !== "string") {
+    throw new Error("Invalid question provided.");
+  }
+
+  const chatHistory = new ChatMessageHistory();
+
+  if (webContent) {
+    await chatHistory.addSystemMessage(`Website content:\n${webContent}`);
+  }
+
+  for (const msg of history) {
+    if (msg.role === 'user') {
+      await chatHistory.addUserMessage(msg.text);
+    } else if (msg.role === 'bot') {
+      await chatHistory.addAIChatMessage(msg.text);
+    }
+  }
+
+  await chatHistory.addSystemMessage('When responding, include the chat history, the website content, and the user message.');
+
+  const memory = new BufferMemory({ chatHistory, returnMessages: true });
+  let model;
+  if (modelChoice === 'gemini') {
+    if (!process.env.GOOGLE_API_KEY) {
+      throw new Error("Missing GOOGLE_API_KEY");
+    }
+    model = new ChatGoogleGenerativeAI({
+      model: 'gemini-2.5-flash',
+      apiKey: process.env.GOOGLE_API_KEY,
+      temperature: 0,
+    });
+  } else {
+    model = new ChatOpenAI({
+      temperature: 0,
+      modelName: 'gpt-4o-mini',
+      apiKey: process.env.OPEN_AI_KEY,
+    });
+  }
+
+  const chain = new ConversationChain({ llm: model, memory });
+
+  try {
+    const res = await chain.call({ input: question });
+    return res.response;
+  } catch (error) {
+    console.error('Error during QA processing:', error);
+    throw new Error('Failed to process the question. Please try again.');
+  }
+};


### PR DESCRIPTION
## Summary
- create `utils/qa` helper for running QA with website context
- update question API route to accept `webContent`
- return cleaned text from the RAG endpoint
- pass scraped content from the chat widget when asking a question

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687bebf2fac48324bbcf8de6ce351921